### PR TITLE
Check if calender insert failed with CMs privacy guard

### DIFF
--- a/Offline-Calendar/src/main/java/org/sufficientlysecure/localcalendar/CalendarController.java
+++ b/Offline-Calendar/src/main/java/org/sufficientlysecure/localcalendar/CalendarController.java
@@ -126,10 +126,9 @@ public class CalendarController {
         // Add calendar
         final ContentValues cv = buildContentValues(displayName, color);
         Uri resultUri = cr.insert(buildCalUri(), cv);
-        Log.d(Constants.TAG, "insert uri: " + resultUri.toString());
-
         if (resultUri == null)
             throw new IllegalArgumentException();
+        Log.d(Constants.TAG, "insert uri: " + resultUri.toString());
 
         /*
          * If Cyanogenmod's Privacy Guard is enabled or Android 4.3 AppOps disallows "calendar read" for this app,


### PR DESCRIPTION
If CyanogenMod's privacy guard is enabled, ContentResolver.insert
returns null. Before the result is checked, we pass the result to the
logger and give rise to an unhandled null pointer exception.

Put the statements in the right order to fix this. The user now gets the
appropriate warning.
